### PR TITLE
Change label name to 'Note Statistics'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "joplin-plugin-note-meta",
+  "name": "joplin-plugin-note-stats",
   "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ joplin.plugins.register({
     // Registering commands
     await joplin.commands.register({
       name: 'View-Dialog',
-      label: 'My Test Command 1',
+      label: 'Note Statistics',
       iconName: 'fas fa-info',
       execute: async () => {
         joplin.views.dialogs.open(handle);


### PR DESCRIPTION
Hi there!

I really like your plugin. I noticed that when I hovered over the icon in the editor toolbar, it said 'My Test Command 1'.
I thought it would be better when it would show 'Note Statistics' instead.

It builds and works under the current Joplin version 1.8.5 

![image](https://user-images.githubusercontent.com/59402820/118257414-e721e700-b4ae-11eb-83e4-6e9e603556cd.png)
